### PR TITLE
Fix typo in user migration comment

### DIFF
--- a/db/migrate/20231121053800_create_users.rb
+++ b/db/migrate/20231121053800_create_users.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-# This migration is created users table.
+# This migration creates the users table.
 class CreateUsers < ActiveRecord::Migration[7.1]
   def change
     create_table :users do |t|


### PR DESCRIPTION
## Summary
- fix typo in the create users migration comment

## Testing
- `bundle exec rspec` *(fails: ruby-3.1.2 is not installed)*

------
https://chatgpt.com/codex/tasks/task_e_68527ef229e08326a81063776513feea